### PR TITLE
support node update for image based shapes

### DIFF
--- a/N2G/N2G_DrawIO.py
+++ b/N2G/N2G_DrawIO.py
@@ -255,6 +255,9 @@ class drawio_diagram:
         """
         node_data = {}
         node = self.current_root.find("./object[@id='{}']".format(id))
+        mxCell_elem = None
+        if not node:
+            node = self.current_root.find("./mxCell[@id='{}']".format(id))
         # update data and url attributes
         node_data.update(data)
         node_data.update(kwargs)
@@ -263,7 +266,11 @@ class drawio_diagram:
         if not label is None:
             node.attrib["label"] = label
         # update style
+        
         mxCell_elem = node.find("./mxCell")
+        if not mxCell_elem:
+            mxCell_elem = node
+
         if os.path.isfile(style[:5000]):
             with open(style, "r") as style_file:
                 mxCell_elem.attrib["style"] = style_file.read()

--- a/N2G/N2G_DrawIO.py
+++ b/N2G/N2G_DrawIO.py
@@ -656,9 +656,12 @@ class drawio_diagram:
             self.nodes_ids.setdefault(diagram_elem.attrib["id"], [])
             self.edges_ids.setdefault(diagram_elem.attrib["id"], [])
             # iterate over mxcells to extract nodes and edges
-            for object in diagram_elem.findall("./mxGraphModel/root/object"):
-                object_id = object.attrib["id"]
-                mxCell = object.find("./mxCell")
+            for object in diagram_elem.findall("./mxGraphModel/root/*"):
+                if object.tag.lower() == 'mxcell':
+                    mxCell = object
+                else:
+                    mxCell = object.find("./mxCell")
+                object_id = object.attrib.get("id")
                 # check if this is the edge
                 if "source" in mxCell.attrib and "target" in mxCell.attrib:
                     self.edges_ids[diagram_elem.attrib["id"]].append(object_id)


### PR DESCRIPTION
Currently image based shapes are not supported in the update_node function.
Image based shapes are not objects, instead they are just mxCells with style information.
It would be great if this gets merged.
