### PR TITLE
Drawio tree layout all on one line.

### DIFF
--- a/N2G/plugins/diagrams/N2G_DrawIO.py
+++ b/N2G/plugins/diagrams/N2G_DrawIO.py
@@ -489,8 +489,6 @@ class drawio_diagram:
             for item in self.current_root.iterfind("./object"):
                 # add edges, item[0] refernece to object's mxCell child tag
                 if item[0].get("source") and item[0].get("target"):
-                    igraph_graph.add_vertex(name=item[0].get("source"))
-                    igraph_graph.add_vertex(name=item[0].get("target"))
                     igraph_graph.add_edge(
                         source=item[0].get("source"), target=item[0].get("target")
                     )

--- a/N2G/plugins/diagrams/N2G_DrawIO.py
+++ b/N2G/plugins/diagrams/N2G_DrawIO.py
@@ -483,7 +483,7 @@ class drawio_diagram:
             )
         # iterate over diagrams and layout elements
         for diagram in self.drawing.findall("./diagram"):
-            igraph_graph = ig()
+            igraph_graph = ig(directed=True)
             self.go_to_diagram(diagram.attrib["name"])
             # populate igraph with nodes and edges from object tags
             for item in self.current_root.iterfind("./object"):


### PR DESCRIPTION
Adding vertices multiple times to igraph without edges between them leads to the nodes not touched by the layout.

Apparently name is not a unique key in igraph, if you add a node with the same node twice, two nodes get added with different node indices.

Removing the node insert for edges seems to fix this, however none of the tests are running locally by just running `pytest` due to some problem with the working directory.