### PR TITLE
We no need to add vertex if it exists

### DIFF
--- a/N2G/plugins/diagrams/N2G_DrawIO.py
+++ b/N2G/plugins/diagrams/N2G_DrawIO.py
@@ -503,9 +503,17 @@ class drawio_diagram:
             # populate igraph with nodes and edges from object tags
             for item in self.current_root.iterfind("./object"):
                 # add edges, item[0] refernece to object's mxCell child tag
-                if item[0].get("source") and item[0].get("target"):
-                    src = igraph_graph.add_vertex(name=item[0].get("source"))
-                    tgt = igraph_graph.add_vertex(name=item[0].get("target"))
+                src = item[0].get("source")
+                tgt = item[0].get("target")
+                if src and tgt:
+                    try:
+                        src = igraph_graph.vs.find(src)
+                    except ValueError:
+                        src = igraph_graph.add_vertex(name=src)
+                    try:
+                        tgt = igraph_graph.vs.find(tgt)
+                    except ValueError:
+                        tgt = igraph_graph.add_vertex(name=tgt)
                     igraph_graph.add_edge(source=src, target=tgt)
                 # add nodes
                 else:


### PR DESCRIPTION
If we have already added vertex earlier, no need to add it again. Moreover it breaks drawio graph.

Before
![out drawio-without-patch](https://github.com/dmulyalin/N2G/assets/1661734/7a8b3e4a-8b97-4eda-bf30-e4fa89670519)

After
![out drawio-with-patch](https://github.com/dmulyalin/N2G/assets/1661734/ef550e01-3375-4a81-b2d0-74fbf0722716)
