### PR TITLE
add all object properties to node

### DIFF
--- a/N2G/plugins/diagrams/N2G_DrawIO.py
+++ b/N2G/plugins/diagrams/N2G_DrawIO.py
@@ -681,6 +681,8 @@ class drawio_diagram:
                     object_tag = ET.fromstring(
                         self.drawio_object_xml.format(id=mxcell.attrib.pop("id"))
                     )
+                    for attr in mxcell.attrib:
+                        object_tag.attrib[attr] = mxcell.attrib[attr]
                     object_tag.append(mxcell)
                     diagram_root.append(object_tag)
                 # check if this is a node

--- a/N2G/plugins/diagrams/N2G_DrawIO.py
+++ b/N2G/plugins/diagrams/N2G_DrawIO.py
@@ -696,6 +696,8 @@ class drawio_diagram:
                     object_tag.append(mxcell)
                     if mxcell.attrib.get("value"):
                         object_tag.attrib["label"] = mxcell.attrib.pop("value")
+                    for attr in mxcell.attrib:
+                        object_tag.attrib[attr] = mxcell.attrib[attr]
                     diagram_root.append(object_tag)
 
             # iterate over object/mxCell to extract nodes and edges


### PR DESCRIPTION
I needed to access the property `style` of the xml object in the node, but the node just had the properties `id` and `label` (with the value of property `value`?!). So I've added this lines so the node have all xml object properties.

### Example:

Before this PR, we had:

```python
>>> diagram.edges_ids
{'NYdg3bHRsR49v2e3w9m-': ['FRgOEqRr26YJtNhKciwV-1']}
>>> diagram.current_root[-3].items()
[('id', 'FRgOEqRr26YJtNhKciwV-1')]
```

With this PR, we have:

```python
>>> diagram.current_root[-3].items()
[('id', 'FRgOEqRr26YJtNhKciwV-1'), ('style', 'rounded=0;orthogonalLoop=1;jettySize=auto;html=1;opacity=20;endArrow=none;endFill=0;jumpStyle=gap;'), ('edge', '1'), ('parent', '1'), ('source', 'FRgOEqRr26YJtNhKciwV-21'), ('target', 'FRgOEqRr26YJtNhKciwV-2')]

```


